### PR TITLE
Fix an issue that incorrect key being removed when reached rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ ratelimit(id).then(...).catch(...);
 opts:
 
 - client: {Object} client of [ioredis](https://github.com/luin/ioredis).
-- limit: {Number} concurrent in duration milliscond, default `1`.
+- limit: {Number} max amount of calls in duration, default `1`.
 - duration: {Number} duration in millisecond, default `1000`.
 - difference: {Number} duration between each operation in millisecond, default `0`.
 - ttl: {Number} expire in millisecond, must greater than or equal to `.duration`, default `86400000`.

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = function (opts) {
           return client
             .multi()
             .zremrangebyscore(redisKey, '-inf', min)  // remove expired ones
-            .zrem(key, member) // remove the one just inserted
+            .zrem(redisKey, member) // remove the one just inserted
             .exec()
             .then(function() {
               return Promise.reject(error);
@@ -67,7 +67,6 @@ module.exports = function (opts) {
         return {
           total: limit,
           remaining: limit - remaining,
-          next: difference,
         };
       });
   };

--- a/index.js
+++ b/index.js
@@ -43,6 +43,15 @@ module.exports = function (opts) {
             return Promise.reject(res[i][0]);
           }
         }
+
+        if (res[3] && res[3][1] > 1) {
+          return client
+            .zrem(redisKey, member) // remove the one just inserted
+            .then(function() {
+              return Promise.reject(error);
+            })
+        }
+
         var remaining = res[2][1];
         if (remaining > limit) {
           return client
@@ -50,14 +59,6 @@ module.exports = function (opts) {
             .zremrangebyscore(redisKey, '-inf', min)  // remove expired ones
             .zrem(key, member) // remove the one just inserted
             .exec()
-            .then(function() {
-              return Promise.reject(error);
-            })
-        }
-
-        if (res[3] && res[3][1] > 1) {
-          return client
-            .zrem(key, member) // remove the one just inserted
             .then(function() {
               return Promise.reject(error);
             })


### PR DESCRIPTION
This issue was raised at `1.3.0`.

- Fix the incorrect key being removed when `key` is defined as function.
- Remove unexpected `next` property which is always equal to `difference`.