### PR TITLE
cleanup expired entries from redis zset during add

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ module.exports = function (opts) {
 
     var redisCommand = client
       .multi()
+      .zremrangebyscore(redisKey, '-inf', `(${min}`) // cleanup anything expired (older than min)
       .zadd(redisKey, items)
       .pexpire(redisKey, ttl)
       .zcount(redisKey, min, max);
@@ -82,7 +83,7 @@ module.exports = function (opts) {
           }
         }
 
-        if (res[3] && res[3][1] > members.length) {
+        if (res[4] && res[4][1] > members.length) {
           return client
             .zrem(redisKey, members) // remove items just inserted
             .then(function() {
@@ -90,7 +91,7 @@ module.exports = function (opts) {
             });
         }
 
-        var original = res[2][1] - members.length;
+        var original = res[3][1] - members.length;
         return runStrategy(redisKey, original, min, members)
           .then(function (added) {
             var total = original + added;


### PR DESCRIPTION
This is a fix for preventing a memory leak in redis. This change is necessary because the zset will continually accumulate new entries and never cleanup if the following conditions are met.
- there is activity at least once per ttl period
- the rate limit is never exceeded

In this situation, the redis key will never be expired, and the zset will never be cleaned up if the rate limit is never exceeded.

For normal operations, the zset must be cleaned up by removing any entires < min which will never be used/counted again.